### PR TITLE
Fixed 2 failing tests in python 2.5, nicer csv.Error in _stringify_list

### DIFF
--- a/unicodecsv/__init__.py
+++ b/unicodecsv/__init__.py
@@ -45,8 +45,8 @@ def _stringify(s, encoding):
 def _stringify_list(l, encoding):
     try:
         return [_stringify(s, encoding) for s in iter(l)]
-    except TypeError:
-        raise csv.Error()
+    except TypeError, e:
+        raise csv.Error(str(e))
 
 def _unicodify(s, encoding):
     if s is None:


### PR DESCRIPTION
Two tests were failing in python 2.5 (test_read_dict_no_fieldnames / test_read_long_with_rest_no_fieldnames).

I've also added a message to the csv.Error raised in _stringify_list, based on what I saw here http://hg.python.org/cpython/file/b48e1b48e670/Lib/csv.py#l50
