### PR TITLE
Remove the redundant _stringify_list call in DictWriter.writeheader

### DIFF
--- a/unicodecsv/__init__.py
+++ b/unicodecsv/__init__.py
@@ -84,7 +84,7 @@ class UnicodeWriter(object):
 
     def writerows(self, rows):
         for row in rows:
-          self.writerow(row)
+            self.writerow(row)
 
     @property
     def dialect(self):
@@ -147,7 +147,6 @@ class DictWriter(csv.DictWriter):
         self.encoding_errors = errors
 
     def writeheader(self):
-        fieldnames = _stringify_list(self.fieldnames, self.encoding, self.encoding_errors)
         header = dict(zip(self.fieldnames, self.fieldnames))
         self.writerow(header)
 


### PR DESCRIPTION
It assigns the encoded value of fieldnames to a local variable, but thevariable
is not used.

Add 2 spaces in UnicodeWriter.writerows to keep the identation consistent with
4 spaces.