### PR TITLE
Make unicodecsv importable under Python 3

### DIFF
--- a/unicodecsv/__init__.py
+++ b/unicodecsv/__init__.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 import csv
-import sys
 
 try:
     from itertools import izip
@@ -51,8 +50,7 @@ def _stringify(s, encoding, errors):
 def _stringify_list(l, encoding, errors='strict'):
     try:
         return [_stringify(s, encoding, errors) for s in iter(l)]
-    except TypeError:
-        _, e, _ = sys.exc_info()
+    except TypeError as e:
         raise csv.Error(str(e))
 
 def _unicodify(s, encoding):


### PR DESCRIPTION
I realize that `unicodecsv` is not necessary and not usable in Python 3. However, I'd like to be able to install and import `unicodecsv` in a project that supports Python 2 and 3. Currently, installation breaks under Python 3 because `unicodecsv` can't be imported.

The following minimal changes allow an installation under Python 3:
- exception catching compatible with Python 2.5 - 3
- catch ImportError for non-existing dependencies
