### PR TITLE
Fixes typo in DictWriter.writeheader

### DIFF
--- a/unicodecsv/__init__.py
+++ b/unicodecsv/__init__.py
@@ -151,7 +151,7 @@ class DictWriter(csv.DictWriter):
 
     def writeheader(self):
         fieldnames = _stringify_list(self.fieldnames, self.encoding, self.encoding_errors)
-        header = dict(zip(self.fieldnames, self.fieldnames))
+        header = dict(zip(self.fieldnames, fieldnames))
         self.writerow(header)
 
 class DictReader(csv.DictReader):


### PR DESCRIPTION
This is the current code for `DictWriter.writeheader()`:

``` python
def writeheader(self):
    fieldnames = _stringify_list(self.fieldnames, self.encoding, self.encoding_errors)
    header = dict(zip(self.fieldnames, self.fieldnames))
    self.writerow(header)
```

As you can see, when `zip()` is called, both arguments are the same (like in the standard library version). In the previous line `fieldnames` is defined, but it's never used. I assume this is a typo and that line 2 of the function should be this: `header = dict(zip(self.fieldnames, fieldnames))`. This pull request fixes that typo.
