### PR TITLE
fixed tests to run under python 3

### DIFF
--- a/runtests.py
+++ b/runtests.py
@@ -1,15 +1,18 @@
-import unittest2
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest
 import doctest
 
 def get_suite():
-    loader = unittest2.TestLoader()
+    loader = unittest.TestLoader()
     suite = loader.discover('unicodecsv')
     suite.addTest(doctest.DocTestSuite('unicodecsv'))
 
     return suite
 
 if __name__ == '__main__':
-    result = unittest2.TestResult()
+    result = unittest.TestResult()
     get_suite().run(result)
     for error in result.errors:
-        print error
+        print(error)

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,15 @@
 #!/usr/bin/env python
 import os
+import sys
 from setuptools import setup, find_packages
 
 version = __import__('unicodecsv').__version__
+
+
+if sys.version_info[0] < 3:
+    tests_require = ['unittest2>=0.5.1']
+else:
+    tests_require = []
 
 setup(
     name='unicodecsv',
@@ -13,7 +20,7 @@ setup(
     author_email='jdunck@gmail.com',
     url='https://github.com/jdunck/python-unicodecsv',
     packages=find_packages(),
-    tests_require=['unittest2>=0.5.1'],
+    tests_require=tests_require,
     test_suite='runtests.get_suite',
     license='BSD License',
     classifiers=['Development Status :: 5 - Production/Stable',

--- a/unicodecsv/__init__.py
+++ b/unicodecsv/__init__.py
@@ -64,7 +64,10 @@ def _unicodify(s, encoding):
 class UnicodeWriter(object):
     """
     >>> import unicodecsv
-    >>> from cStringIO import StringIO
+    >>> try:
+    ...     from cStringIO import StringIO
+    ... except ImportError:
+    ...     from io import StringIO
     >>> f = StringIO()
     >>> w = unicodecsv.writer(f, encoding='utf-8')
     >>> w.writerow((u'é', u'ñ'))
@@ -128,7 +131,10 @@ reader = UnicodeReader
 
 class DictWriter(csv.DictWriter):
     """
-    >>> from cStringIO import StringIO
+    >>> try:
+    ...     from cStringIO import StringIO
+    ... except ImportError:
+    ...     from io import StringIO
     >>> f = StringIO()
     >>> w = DictWriter(f, ['a', u'ñ', 'b'], restval=u'î')
     >>> w.writerow({'a':'1', u'ñ':'2'})
@@ -156,7 +162,10 @@ class DictWriter(csv.DictWriter):
 
 class DictReader(csv.DictReader):
     """
-    >>> from cStringIO import StringIO
+    >>> try:
+    ...     from cStringIO import StringIO
+    ... except ImportError:
+    ...     from io import StringIO
     >>> f = StringIO()
     >>> w = DictWriter(f, fieldnames=['name', 'place'])
     >>> w.writerow({'name': 'Cary Grant', 'place': 'hollywood'})
@@ -164,11 +173,11 @@ class DictReader(csv.DictReader):
     >>> w.writerow({'name': u'Willam ø. Unicoder', 'place': u'éSpandland'})
     >>> f.seek(0)
     >>> r = DictReader(f, fieldnames=['name', 'place'])
-    >>> print r.next() == {'name': 'Cary Grant', 'place': 'hollywood'}
+    >>> print(r.next() == {'name': 'Cary Grant', 'place': 'hollywood'})
     True
-    >>> print r.next() == {'name': 'Nathan Brillstone', 'place': u'øLand'}
+    >>> print(r.next() == {'name': 'Nathan Brillstone', 'place': u'øLand'})
     True
-    >>> print r.next() == {'name': u'Willam ø. Unicoder', 'place': u'éSpandland'}
+    >>> print(r.next() == {'name': u'Willam ø. Unicoder', 'place': u'éSpandland'})
     True
     """
     def __init__(self, csvfile, fieldnames=None, restkey=None, restval=None,

--- a/unicodecsv/test.py
+++ b/unicodecsv/test.py
@@ -5,8 +5,14 @@
 from codecs import EncodedFile
 import os
 import sys
-import unittest2 as unittest
-from StringIO import StringIO
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest
+try:
+    from StringIO import StringIO
+except ImportError:
+    from io import StringIO
 import tempfile
 import unicodecsv as csv
 
@@ -803,7 +809,11 @@ class TestArrayWrites(unittest.TestCase):
 
     def test_char_write(self):
         import array, string
-        a = array.array('c', string.letters)
+        letters = getattr(string, 'letters', string.ascii_letters)
+        try:
+            a = array.array('c', letters)
+        except ValueError:
+            a = array.array('u', letters)
         fd, name = tempfile.mkstemp()
         fileobj = os.fdopen(fd, "w+b")
         try:


### PR DESCRIPTION
Test still fails under python 3 because of `unicode()` usage, but at least now they runs.

I can work on making the tests pass (ref #26) when I'll get more spare time.
