### PR TITLE
Fix TypeError bug in DictReader when file is empty

### DIFF
--- a/unicodecsv/__init__.py
+++ b/unicodecsv/__init__.py
@@ -183,8 +183,11 @@ class DictReader(csv.DictReader):
             # Python 2.5 fieldnames workaround. (http://bugs.python.org/issue3436)
             reader = UnicodeReader(csvfile, dialect, encoding=encoding, *args, **kwds)
             self.fieldnames = _stringify_list(reader.next(), reader.encoding)
-        self.unicode_fieldnames = [_unicodify(f, encoding) for f in
-                                   self.fieldnames]
+        if self.fieldnames is not None:
+            self.unicode_fieldnames = [_unicodify(f, encoding) for f in
+                                       self.fieldnames]
+        else:
+            self.fieldnames = None
         self.unicode_restkey = _unicodify(restkey, encoding)
 
     def next(self):

--- a/unicodecsv/test.py
+++ b/unicodecsv/test.py
@@ -745,6 +745,20 @@ class TestDictFields(unittest.TestCase):
         self.assertEqual(reader.next(), {"1": '1', "2": '2', "3": 'abc',
                                          "4": '4', "5": '5', "6": '6'})
 
+    def test_empty_file(self):
+        fd, name = tempfile.mkstemp()
+        f = os.fdopen(fd, "w+b")
+        try:
+            f.write("")
+            f.seek(0)
+            reader = csv.DictReader(f)
+            self.assertEqual(reader.fieldnames, None)
+            with self.assertRaises(StopIteration):
+                reader.next()
+        finally:
+            f.close()
+            os.unlink(name)
+
 class TestArrayWrites(unittest.TestCase):
     def test_int_write(self):
         import array


### PR DESCRIPTION
Instantiating a `unicodecsv.DictReader` on an empty file currently raises a `TypeError: 'NoneType' object is not iterable` exception. For example:

```python
import unicodecsv

with open('empty_file.csv') as f:
    reader = unicodecsv.DictReader(f)  # raises TypeError
```

This commit fixes the bug. I'm happy to respond to feedback.

Thanks!