### PR TITLE
#39 | Retain the order of coulumns in Dictreader

### DIFF
--- a/unicodecsv/__init__.py
+++ b/unicodecsv/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-import csv
+import csv, collections
 try:
     from itertools import izip
 except ImportError:
@@ -189,7 +189,7 @@ class DictReader(csv.DictReader):
 
     def next(self):
         row = csv.DictReader.next(self)
-        result = dict((uni_key, row[str_key]) for (str_key, uni_key) in
+        result = collections.OrderedDict((uni_key, row[str_key]) for (str_key, uni_key) in
                       izip(self.fieldnames, self.unicode_fieldnames))
         rest = row.get(self.restkey)
         if rest:

--- a/unicodecsv/test.py
+++ b/unicodecsv/test.py
@@ -745,6 +745,11 @@ class TestDictFields(unittest.TestCase):
         self.assertEqual(reader.next(), {"1": '1', "2": '2', "3": 'abc',
                                          "4": '4', "5": '5', "6": '6'})
 
+    def test_read_retain_order_of_columns(self):
+        reader = csv.DictReader(["1,2,3,4"],
+                                fieldnames="foo bar baz qux".split())
+        self.assertEqual(reader.next().keys(), ["foo", "bar", "baz", "qux"])
+
 class TestArrayWrites(unittest.TestCase):
     def test_int_write(self):
         import array


### PR DESCRIPTION
Fix for https://github.com/jdunck/python-unicodecsv/issues/39