### PR TITLE
Updated method to use local variable instead of instance variable

### DIFF
--- a/unicodecsv/__init__.py
+++ b/unicodecsv/__init__.py
@@ -151,7 +151,7 @@ class DictWriter(csv.DictWriter):
 
     def writeheader(self):
         fieldnames = _stringify_list(self.fieldnames, self.encoding, self.encoding_errors)
-        header = dict(zip(self.fieldnames, self.fieldnames))
+        header = dict(zip(fieldnames, fieldnames))
         self.writerow(header)
 
 class DictReader(csv.DictReader):


### PR DESCRIPTION
As discussed in https://github.com/jdunck/python-unicodecsv/issues/43, this changes the `writeheader` method to use the 'processed' local `fieldnames` variable instead of `self.fieldnames`.