### PR TITLE
Remove the redundant _stringify_list call in DictWriter.writeheader

### DIFF
--- a/unicodecsv/__init__.py
+++ b/unicodecsv/__init__.py
@@ -154,8 +154,7 @@ class DictWriter(csv.DictWriter):
         self.encoding_errors = errors
 
     def writeheader(self):
-        fieldnames = _stringify_list(self.fieldnames, self.encoding, self.encoding_errors)
-        header = dict(zip(fieldnames, fieldnames))
+        header = dict(zip(self.fieldnames, self.fieldnames))
         self.writerow(header)
 
 class DictReader(csv.DictReader):


### PR DESCRIPTION
Originally authored by @reterVision in #18.