### PR TITLE
Reformats code to be pep8 compatible

### DIFF
--- a/runtests.py
+++ b/runtests.py
@@ -1,6 +1,7 @@
 import unittest2
 import doctest
 
+
 def get_suite():
     loader = unittest2.TestLoader()
     suite = loader.discover('unicodecsv')

--- a/setup.py
+++ b/setup.py
@@ -2,13 +2,17 @@
 import os
 from setuptools import setup, find_packages
 
+DIR_NAME = os.path.dirname(__file__)
 version = __import__('unicodecsv').__version__
 
 setup(
     name='unicodecsv',
     version=version,
-    description="Python2's stdlib csv module is nice, but it doesn't support unicode. This module is a drop-in replacement which *does*.",
-    long_description=open(os.path.join(os.path.dirname(__file__), 'README.rst'), 'r').read(),
+    description=(
+        "Python2's stdlib csv module is nice, but it doesn't support unicode. "
+        "This module is a drop-in replacement which *does*."
+    ),
+    long_description=open(os.path.join(DIR_NAME, 'README.rst'), 'r').read(),
     author='Jeremy Dunck',
     author_email='jdunck@gmail.com',
     url='https://github.com/jdunck/python-unicodecsv',
@@ -16,13 +20,14 @@ setup(
     tests_require=['unittest2>=0.5.1'],
     test_suite='runtests.get_suite',
     license='BSD License',
-    classifiers=['Development Status :: 5 - Production/Stable',
-                'Intended Audience :: Developers',
-                'License :: OSI Approved :: BSD License',
-                'Natural Language :: English',
-                'Programming Language :: Python :: 2.5',
-                'Programming Language :: Python :: 2.6',
-                'Programming Language :: Python :: 2.7',
-                'Programming Language :: Python :: Implementation :: CPython',],
+    classifiers=[
+        'Development Status :: 5 - Production/Stable',
+        'Intended Audience :: Developers',
+        'License :: OSI Approved :: BSD License',
+        'Natural Language :: English',
+        'Programming Language :: Python :: 2.5',
+        'Programming Language :: Python :: 2.6',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: Implementation :: CPython'
+    ],
 )
-

--- a/unicodecsv/__init__.py
+++ b/unicodecsv/__init__.py
@@ -5,9 +5,9 @@ try:
 except ImportError:
     izip = zip
 
-#http://semver.org/
+# http://semver.org/
 VERSION = (0, 10, 1)
-__version__ = ".".join(map(str,VERSION))
+__version__ = ".".join(map(str, VERSION))
 
 pass_throughs = [
     'register_dialect',
@@ -33,24 +33,27 @@ __all__ = [
 ] + pass_throughs
 
 for prop in pass_throughs:
-    globals()[prop]=getattr(csv, prop)
+    globals()[prop] = getattr(csv, prop)
+
 
 def _stringify(s, encoding, errors):
     if s is None:
         return ''
     if isinstance(s, unicode):
         return s.encode(encoding, errors)
-    elif isinstance(s, (int , float)):
-        pass #let csv.QUOTE_NONNUMERIC do its thing.
+    elif isinstance(s, (int, float)):
+        pass  # let csv.QUOTE_NONNUMERIC do its thing.
     elif not isinstance(s, str):
-        s=str(s)
+        s = str(s)
     return s
+
 
 def _stringify_list(l, encoding, errors='strict'):
     try:
         return [_stringify(s, encoding, errors) for s in iter(l)]
     except TypeError as e:
         raise csv.Error(str(e))
+
 
 def _unicodify(s, encoding):
     if s is None:
@@ -60,6 +63,7 @@ def _unicodify(s, encoding):
     elif isinstance(s, str):
         return s.decode(encoding)
     return s
+
 
 class UnicodeWriter(object):
     """
@@ -83,7 +87,8 @@ class UnicodeWriter(object):
         self.encoding_errors = errors
 
     def writerow(self, row):
-        return self.writer.writerow(_stringify_list(row, self.encoding, self.encoding_errors))
+        return self.writer.writerow(_stringify_list(row, self.encoding,
+                                                    self.encoding_errors))
 
     def writerows(self, rows):
         for row in rows:
@@ -94,17 +99,21 @@ class UnicodeWriter(object):
         return self.writer.dialect
 writer = UnicodeWriter
 
+
 class UnicodeReader(object):
     def __init__(self, f, dialect=None, encoding='utf-8', errors='strict',
                  **kwds):
-        format_params = ['delimiter', 'doublequote', 'escapechar', 'lineterminator', 'quotechar', 'quoting', 'skipinitialspace']
+        format_params = ['delimiter', 'doublequote', 'escapechar',
+                         'lineterminator', 'quotechar', 'quoting',
+                         'skipinitialspace']
         if dialect is None:
-            if not any([kwd_name in format_params for kwd_name in kwds.keys()]):
+            if not any([kwd in format_params for kwd in kwds.keys()]):
                 dialect = csv.excel
         self.reader = csv.reader(f, dialect, **kwds)
         self.encoding = encoding
         self.encoding_errors = errors
-        self._parse_numerics = bool(self.dialect.quoting & csv.QUOTE_NONNUMERIC)
+        self._parse_numerics = bool(self.dialect.quoting &
+                                    csv.QUOTE_NONNUMERIC)
 
     def next(self):
         row = self.reader.next()
@@ -114,9 +123,11 @@ class UnicodeReader(object):
         if self._parse_numerics:
             float_ = float
             return [(value if isinstance(value, float_) else
-                     unicode_(value, encoding, encoding_errors)) for value in row]
+                     unicode_(value, encoding, encoding_errors))
+                    for value in row]
         else:
-            return [unicode_(value, encoding, encoding_errors) for value in row]
+            return [unicode_(value, encoding, encoding_errors) for value in
+                    row]
 
     def __iter__(self):
         return self
@@ -129,6 +140,7 @@ class UnicodeReader(object):
     def line_num(self):
         return self.reader.line_num
 reader = UnicodeReader
+
 
 class DictWriter(csv.DictWriter):
     """
@@ -147,16 +159,22 @@ class DictWriter(csv.DictWriter):
     >>> r.next() == {'a': u'\xc3\xa9', u'ñ':'2', 'r': [u'\xc3\xae']}
     True
     """
-    def __init__(self, csvfile, fieldnames, restval='', extrasaction='raise', dialect='excel', encoding='utf-8', errors='strict', *args, **kwds):
+    def __init__(self, csvfile, fieldnames, restval='', extrasaction='raise',
+                 dialect='excel', encoding='utf-8', errors='strict', *args,
+                 **kwds):
         self.encoding = encoding
-        csv.DictWriter.__init__(self, csvfile, fieldnames, restval, extrasaction, dialect, *args, **kwds)
-        self.writer = UnicodeWriter(csvfile, dialect, encoding=encoding, errors=errors, *args, **kwds)
+        csv.DictWriter.__init__(self, csvfile, fieldnames, restval,
+                                extrasaction, dialect, *args, **kwds)
+        self.writer = UnicodeWriter(csvfile, dialect, encoding=encoding,
+                                    errors=errors, *args, **kwds)
         self.encoding_errors = errors
 
     def writeheader(self):
-        fieldnames = _stringify_list(self.fieldnames, self.encoding, self.encoding_errors)
+        fieldnames = _stringify_list(self.fieldnames, self.encoding,
+                                     self.encoding_errors)
         header = dict(zip(fieldnames, fieldnames))
         self.writerow(header)
+
 
 class DictReader(csv.DictReader):
     """
@@ -165,14 +183,14 @@ class DictReader(csv.DictReader):
     >>> w = DictWriter(f, fieldnames=['name', 'place'])
     >>> w.writerow({'name': 'Cary Grant', 'place': 'hollywood'})
     >>> w.writerow({'name': 'Nathan Brillstone', 'place': u'øLand'})
-    >>> w.writerow({'name': u'Willam ø. Unicoder', 'place': u'éSpandland'})
+    >>> w.writerow({'name': u'Willam ø. Unicoder', 'place': u'éLand'})
     >>> f.seek(0)
     >>> r = DictReader(f, fieldnames=['name', 'place'])
     >>> print r.next() == {'name': 'Cary Grant', 'place': 'hollywood'}
     True
     >>> print r.next() == {'name': 'Nathan Brillstone', 'place': u'øLand'}
     True
-    >>> print r.next() == {'name': u'Willam ø. Unicoder', 'place': u'éSpandland'}
+    >>> print r.next() == {'name': u'Willam ø. Unicoder', 'place': u'éLand'}
     True
     """
     def __init__(self, csvfile, fieldnames=None, restkey=None, restval=None,
@@ -180,12 +198,14 @@ class DictReader(csv.DictReader):
                  **kwds):
         if fieldnames is not None:
             fieldnames = _stringify_list(fieldnames, encoding)
-        csv.DictReader.__init__(self, csvfile, fieldnames, restkey, restval, dialect, *args, **kwds)
+        csv.DictReader.__init__(self, csvfile, fieldnames, restkey, restval,
+                                dialect, *args, **kwds)
         self.reader = UnicodeReader(csvfile, dialect, encoding=encoding,
                                     errors=errors, *args, **kwds)
         if fieldnames is None and not hasattr(csv.DictReader, 'fieldnames'):
-            # Python 2.5 fieldnames workaround. (http://bugs.python.org/issue3436)
-            reader = UnicodeReader(csvfile, dialect, encoding=encoding, *args, **kwds)
+            # Python 2.5 fieldnames workaround http://bugs.python.org/issue3436
+            reader = UnicodeReader(csvfile, dialect, encoding=encoding, *args,
+                                   **kwds)
             self.fieldnames = _stringify_list(reader.next(), reader.encoding)
         self.unicode_fieldnames = [_unicodify(f, encoding) for f in
                                    self.fieldnames]

--- a/unicodecsv/test.py
+++ b/unicodecsv/test.py
@@ -10,9 +10,10 @@ from StringIO import StringIO
 import tempfile
 import unicodecsv as csv
 
-# pypy and cpython differ under which exception is raised under some circumstances
-# e.g. whether a module is written in C or not.
+# pypy and cpython differ under which exception is raised under some
+# circumstances, e.g. whether a module is written in C or not.
 py_compat_exc = (TypeError, AttributeError)
+
 
 class Test_Csv(unittest.TestCase):
     """
@@ -23,9 +24,9 @@ class Test_Csv(unittest.TestCase):
     def _test_arg_valid(self, ctor, arg):
         self.assertRaises(py_compat_exc, ctor)
         self.assertRaises(py_compat_exc, ctor, None)
-        self.assertRaises(py_compat_exc, ctor, arg, bad_attr = 0)
-        self.assertRaises(py_compat_exc, ctor, arg, delimiter = 0)
-        self.assertRaises(py_compat_exc, ctor, arg, delimiter = 'XX')
+        self.assertRaises(py_compat_exc, ctor, arg, bad_attr=0)
+        self.assertRaises(py_compat_exc, ctor, arg, delimiter=0)
+        self.assertRaises(py_compat_exc, ctor, arg, delimiter='XX')
         self.assertRaises(csv.Error, ctor, arg, 'foo')
         self.assertRaises(py_compat_exc, ctor, arg, delimiter=None)
         self.assertRaises(py_compat_exc, ctor, arg, delimiter=1)
@@ -57,7 +58,8 @@ class Test_Csv(unittest.TestCase):
         self.assertEqual(obj.dialect.strict, False)
         # Try deleting or changing attributes (they are read-only)
         self.assertRaises(py_compat_exc, delattr, obj.dialect, 'delimiter')
-        self.assertRaises(py_compat_exc, setattr, obj.dialect, 'delimiter', ':')
+        self.assertRaises(py_compat_exc, setattr, obj.dialect, 'delimiter',
+                          ':')
         self.assertRaises(py_compat_exc, delattr, obj.dialect, 'quoting')
         self.assertRaises(py_compat_exc, setattr, obj.dialect,
                           'quoting', None)
@@ -93,14 +95,14 @@ class Test_Csv(unittest.TestCase):
     def _test_dialect_attrs(self, ctor, *args):
         # Now try with dialect-derived options
         class dialect:
-            delimiter='-'
-            doublequote=False
-            escapechar='^'
-            lineterminator='$'
-            quotechar='#'
-            quoting=csv.QUOTE_ALL
-            skipinitialspace=True
-            strict=False
+            delimiter = '-'
+            doublequote = False
+            escapechar = '^'
+            lineterminator = '$'
+            quotechar = '#'
+            quoting = csv.QUOTE_ALL
+            skipinitialspace = True
+            strict = False
         args = args + (dialect,)
         obj = ctor(*args)
         self.assertEqual(obj.dialect.delimiter, '-')
@@ -117,7 +119,6 @@ class Test_Csv(unittest.TestCase):
 
     def test_writer_dialect_attrs(self):
         self._test_dialect_attrs(csv.writer, StringIO())
-
 
     def _write_test(self, fields, expect, **kwargs):
         fd, name = tempfile.mkstemp()
@@ -137,59 +138,65 @@ class Test_Csv(unittest.TestCase):
         self._write_test((), '')
         self._write_test([None], '""')
         self.assertRaises(csv.Error, self._write_test,
-                          [None], None, quoting = csv.QUOTE_NONE)
+                          [None], None, quoting=csv.QUOTE_NONE)
         # Check that exceptions are passed up the chain
+
         class BadList:
+
             def __len__(self):
-                return 10;
+                return 10
+
             def __getitem__(self, i):
                 if i > 2:
                     raise IOError
         self.assertRaises(IOError, self._write_test, BadList(), '')
+
         class BadItem:
+
             def __str__(self):
                 raise IOError
+
         self.assertRaises(IOError, self._write_test, [BadItem()], '')
 
     def test_write_bigfield(self):
         # This exercises the buffer realloc functionality
         bigstring = 'X' * 50000
-        self._write_test([bigstring,bigstring], '%s,%s' % \
+        self._write_test([bigstring, bigstring], '%s,%s' %
                          (bigstring, bigstring))
 
     def test_write_quoting(self):
-        self._write_test(['a',1,'p,q'], 'a,1,"p,q"')
+        self._write_test(['a', 1, 'p,q'], 'a,1,"p,q"')
         self.assertRaises(csv.Error,
                           self._write_test,
-                          ['a',1,'p,q'], 'a,1,p,q',
-                          quoting = csv.QUOTE_NONE)
-        self._write_test(['a',1,'p,q'], 'a,1,"p,q"',
-                         quoting = csv.QUOTE_MINIMAL)
-        self._write_test(['a',1,'p,q'], '"a",1,"p,q"',
-                         quoting = csv.QUOTE_NONNUMERIC)
-        self._write_test(['a',1,'p,q'], '"a","1","p,q"',
-                         quoting = csv.QUOTE_ALL)
-        self._write_test(['a\nb',1], '"a\nb","1"',
-                         quoting = csv.QUOTE_ALL)
+                          ['a', 1, 'p,q'], 'a,1,p,q',
+                          quoting=csv.QUOTE_NONE)
+        self._write_test(['a', 1, 'p,q'], 'a,1,"p,q"',
+                         quoting=csv.QUOTE_MINIMAL)
+        self._write_test(['a', 1, 'p,q'], '"a",1,"p,q"',
+                         quoting=csv.QUOTE_NONNUMERIC)
+        self._write_test(['a', 1, 'p,q'], '"a","1","p,q"',
+                         quoting=csv.QUOTE_ALL)
+        self._write_test(['a\nb', 1], '"a\nb","1"',
+                         quoting=csv.QUOTE_ALL)
 
     def test_write_escape(self):
-        self._write_test(['a',1,'p,q'], 'a,1,"p,q"',
+        self._write_test(['a', 1, 'p,q'], 'a,1,"p,q"',
                          escapechar='\\')
         self.assertRaises(csv.Error,
                           self._write_test,
-                          ['a',1,'p,"q"'], 'a,1,"p,\\"q\\""',
+                          ['a', 1, 'p,"q"'], 'a,1,"p,\\"q\\""',
                           escapechar=None, doublequote=False)
-        self._write_test(['a',1,'p,"q"'], 'a,1,"p,\\"q\\""',
-                         escapechar='\\', doublequote = False)
+        self._write_test(['a', 1, 'p,"q"'], 'a,1,"p,\\"q\\""',
+                         escapechar='\\', doublequote=False)
         self._write_test(['"'], '""""',
-                         escapechar='\\', quoting = csv.QUOTE_MINIMAL)
+                         escapechar='\\', quoting=csv.QUOTE_MINIMAL)
         self._write_test(['"'], '\\"',
-                         escapechar='\\', quoting = csv.QUOTE_MINIMAL,
-                         doublequote = False)
+                         escapechar='\\', quoting=csv.QUOTE_MINIMAL,
+                         doublequote=False)
         self._write_test(['"'], '\\"',
-                         escapechar='\\', quoting = csv.QUOTE_NONE)
-        self._write_test(['a',1,'p,q'], 'a,1,p\\,q',
-                         escapechar='\\', quoting = csv.QUOTE_NONE)
+                         escapechar='\\', quoting=csv.QUOTE_NONE)
+        self._write_test(['a', 1, 'p,q'], 'a,1,p\\,q',
+                         escapechar='\\', quoting=csv.QUOTE_NONE)
 
     def test_writerows(self):
         class BrokenFile:
@@ -202,7 +209,7 @@ class Test_Csv(unittest.TestCase):
         try:
             writer = csv.writer(fileobj)
             self.assertRaises(TypeError, writer.writerows, None)
-            writer.writerows([['a','b'],['c','d']])
+            writer.writerows([['a', 'b'], ['c', 'd']])
             fileobj.seek(0)
             self.assertEqual(fileobj.read(), "a,b\r\nc,d\r\n")
         finally:
@@ -218,17 +225,17 @@ class Test_Csv(unittest.TestCase):
         self._read_test([], [])
         self._read_test([''], [[]])
         self.assertRaises(csv.Error, self._read_test,
-                          ['"ab"c'], None, strict = 1)
+                          ['"ab"c'], None, strict=1)
         # cannot handle null bytes for the moment
         self.assertRaises(csv.Error, self._read_test,
-                          ['ab\0c'], None, strict = 1)
-        self._read_test(['"ab"c'], [['abc']], doublequote = 0)
+                          ['ab\0c'], None, strict=1)
+        self._read_test(['"ab"c'], [['abc']], doublequote=0)
 
     def test_read_eol(self):
-        self._read_test(['a,b'], [['a','b']])
-        self._read_test(['a,b\n'], [['a','b']])
-        self._read_test(['a,b\r\n'], [['a','b']])
-        self._read_test(['a,b\r'], [['a','b']])
+        self._read_test(['a,b'], [['a', 'b']])
+        self._read_test(['a,b\n'], [['a', 'b']])
+        self._read_test(['a,b\r\n'], [['a', 'b']])
+        self._read_test(['a,b\r'], [['a', 'b']])
         self.assertRaises(csv.Error, self._read_test, ['a,b\rc,d'], [])
         self.assertRaises(csv.Error, self._read_test, ['a,b\nc,d'], [])
         self.assertRaises(csv.Error, self._read_test, ['a,b\r\nc,d'], [])
@@ -275,7 +282,7 @@ class Test_Csv(unittest.TestCase):
         try:
             writer = csv.writer(fileobj)
             self.assertRaises(TypeError, writer.writerows, None)
-            rows = [['a\nb','b'],['c','x\r\nd']]
+            rows = [['a\nb', 'b'], ['c', 'x\r\nd']]
             writer.writerows(rows)
             fileobj.seek(0)
             for i, row in enumerate(csv.reader(fileobj)):
@@ -284,7 +291,9 @@ class Test_Csv(unittest.TestCase):
             fileobj.close()
             os.unlink(name)
 
+
 class TestDialectRegistry(unittest.TestCase):
+
     def test_registry_badargs(self):
         self.assertRaises(TypeError, csv.list_dialects, None)
         self.assertRaises(TypeError, csv.get_dialect)
@@ -352,8 +361,10 @@ class TestDialectRegistry(unittest.TestCase):
     def test_dialect_apply(self):
         class testA(csv.excel):
             delimiter = "\t"
+
         class testB(csv.excel):
             delimiter = ":"
+
         class testC(csv.excel):
             delimiter = "|"
 
@@ -363,7 +374,7 @@ class TestDialectRegistry(unittest.TestCase):
             fileobj = os.fdopen(fd, "w+b")
             try:
                 writer = csv.writer(fileobj)
-                writer.writerow([1,2,3])
+                writer.writerow([1, 2, 3])
                 fileobj.seek(0)
                 self.assertEqual(fileobj.read(), "1,2,3\r\n")
             finally:
@@ -374,7 +385,7 @@ class TestDialectRegistry(unittest.TestCase):
             fileobj = os.fdopen(fd, "w+b")
             try:
                 writer = csv.writer(fileobj, testA)
-                writer.writerow([1,2,3])
+                writer.writerow([1, 2, 3])
                 fileobj.seek(0)
                 self.assertEqual(fileobj.read(), "1\t2\t3\r\n")
             finally:
@@ -385,7 +396,7 @@ class TestDialectRegistry(unittest.TestCase):
             fileobj = os.fdopen(fd, "w+b")
             try:
                 writer = csv.writer(fileobj, dialect=testB())
-                writer.writerow([1,2,3])
+                writer.writerow([1, 2, 3])
                 fileobj.seek(0)
                 self.assertEqual(fileobj.read(), "1:2:3\r\n")
             finally:
@@ -396,7 +407,7 @@ class TestDialectRegistry(unittest.TestCase):
             fileobj = os.fdopen(fd, "w+b")
             try:
                 writer = csv.writer(fileobj, dialect='testC')
-                writer.writerow([1,2,3])
+                writer.writerow([1, 2, 3])
                 fileobj.seek(0)
                 self.assertEqual(fileobj.read(), "1|2|3\r\n")
             finally:
@@ -407,7 +418,7 @@ class TestDialectRegistry(unittest.TestCase):
             fileobj = os.fdopen(fd, "w+b")
             try:
                 writer = csv.writer(fileobj, dialect=testA, delimiter=';')
-                writer.writerow([1,2,3])
+                writer.writerow([1, 2, 3])
                 fileobj.seek(0)
                 self.assertEqual(fileobj.read(), "1;2;3\r\n")
             finally:
@@ -419,20 +430,22 @@ class TestDialectRegistry(unittest.TestCase):
 
     def test_bad_dialect(self):
         # Unknown parameter
-        self.assertRaises(TypeError, csv.reader, [], bad_attr = 0)
+        self.assertRaises(TypeError, csv.reader, [], bad_attr=0)
         # Bad values
-        self.assertRaises(TypeError, csv.reader, [], delimiter = None)
-        self.assertRaises(TypeError, csv.reader, [], quoting = -1)
-        self.assertRaises(TypeError, csv.reader, [], quoting = 100)
+        self.assertRaises(TypeError, csv.reader, [], delimiter=None)
+        self.assertRaises(TypeError, csv.reader, [], quoting=-1)
+        self.assertRaises(TypeError, csv.reader, [], quoting=100)
+
 
 class TestCsvBase(unittest.TestCase):
+
     def readerAssertEqual(self, input, expected_result):
         fd, name = tempfile.mkstemp()
         fileobj = os.fdopen(fd, "w+b")
         try:
             fileobj.write(input)
             fileobj.seek(0)
-            reader = csv.reader(fileobj, dialect = self.dialect)
+            reader = csv.reader(fileobj, dialect=self.dialect)
             fields = list(reader)
             self.assertEqual(fields, expected_result)
         finally:
@@ -443,13 +456,14 @@ class TestCsvBase(unittest.TestCase):
         fd, name = tempfile.mkstemp()
         fileobj = os.fdopen(fd, "w+b")
         try:
-            writer = csv.writer(fileobj, dialect = self.dialect)
+            writer = csv.writer(fileobj, dialect=self.dialect)
             writer.writerows(input)
             fileobj.seek(0)
             self.assertEqual(fileobj.read(), expected_result)
         finally:
             fileobj.close()
             os.unlink(name)
+
 
 class TestDialectExcel(TestCsvBase):
     dialect = 'excel'
@@ -458,7 +472,7 @@ class TestDialectExcel(TestCsvBase):
         self.readerAssertEqual('abc', [['abc']])
 
     def test_simple(self):
-        self.readerAssertEqual('1,2,3,4,5', [['1','2','3','4','5']])
+        self.readerAssertEqual('1,2,3,4,5', [['1', '2', '3', '4', '5']])
 
     def test_blankline(self):
         self.readerAssertEqual('', [])
@@ -470,10 +484,10 @@ class TestDialectExcel(TestCsvBase):
         self.readerAssertEqual('""', [['']])
 
     def test_singlequoted_left_empty(self):
-        self.readerAssertEqual('"",', [['','']])
+        self.readerAssertEqual('"",', [['', '']])
 
     def test_singlequoted_right_empty(self):
-        self.readerAssertEqual(',""', [['','']])
+        self.readerAssertEqual(',""', [['', '']])
 
     def test_single_quoted_quote(self):
         self.readerAssertEqual('""""', [['"']])
@@ -510,10 +524,12 @@ class TestDialectExcel(TestCsvBase):
                                  '5', '6']])
 
     def test_quoted_quote(self):
-        self.readerAssertEqual('1,2,3,"""I see,"" said the blind man","as he picked up his hammer and saw"',
-                               [['1', '2', '3',
-                                 '"I see," said the blind man',
-                                 'as he picked up his hammer and saw']])
+        self.readerAssertEqual(
+            '1,2,3,"""I see,"" said the blind man","as he picked up his '
+            'hammer and saw"',
+            [['1', '2', '3',
+              '"I see," said the blind man',
+              'as he picked up his hammer and saw']])
 
     def test_quoted_nl(self):
         input = '''\
@@ -525,7 +541,7 @@ hammer and saw"
                                [['1', '2', '3',
                                    '"I see,"\nsaid the blind man',
                                    'as he picked up his\nhammer and saw'],
-                                ['9','8','7','6']])
+                                ['9', '8', '7', '6']])
 
     def test_dubious_quote(self):
         self.readerAssertEqual('12,12,1",', [['12', '12', '1"', '']])
@@ -540,7 +556,8 @@ hammer and saw"
         self.writerAssertEqual([[1, 2, 'abc', 3, 4]], '1,2,abc,3,4\r\n')
 
     def test_quotes(self):
-        self.writerAssertEqual([[1, 2, 'a"bc"', 3, 4]], '1,2,"a""bc""",3,4\r\n')
+        self.writerAssertEqual([[1, 2, 'a"bc"', 3, 4]],
+                               '1,2,"a""bc""",3,4\r\n')
 
     def test_quote_fieldsep(self):
         self.writerAssertEqual([['abc,def']], '"abc,def"\r\n')
@@ -548,9 +565,11 @@ hammer and saw"
     def test_newlines(self):
         self.writerAssertEqual([[1, 2, 'a\nbc', 3, 4]], '1,2,"a\nbc",3,4\r\n')
 
+
 class EscapedExcel(csv.excel):
     quoting = csv.QUOTE_NONE
     escapechar = '\\'
+
 
 class TestEscapedExcel(TestCsvBase):
     dialect = EscapedExcel()
@@ -561,9 +580,11 @@ class TestEscapedExcel(TestCsvBase):
     def test_read_escape_fieldsep(self):
         self.readerAssertEqual('abc\\,def\r\n', [['abc,def']])
 
+
 class QuotedEscapedExcel(csv.excel):
     quoting = csv.QUOTE_NONNUMERIC
     escapechar = '\\'
+
 
 class TestQuotedEscapedExcel(TestCsvBase):
     dialect = QuotedEscapedExcel()
@@ -574,20 +595,21 @@ class TestQuotedEscapedExcel(TestCsvBase):
     def test_read_escape_fieldsep(self):
         self.readerAssertEqual('"abc\\,def"\r\n', [['abc,def']])
 
+
 class TestDictFields(unittest.TestCase):
-    ### "long" means the row is longer than the number of fieldnames
-    ### "short" means there are fewer elements in the row than fieldnames
+    # "long" means the row is longer than the number of fieldnames
+    # "short" means there are fewer elements in the row than fieldnames
     def test_write_simple_dict(self):
         fd, name = tempfile.mkstemp()
         fileobj = open(name, 'w+b')
         try:
-            writer = csv.DictWriter(fileobj, fieldnames = ["f1", "f2", "f3"])
+            writer = csv.DictWriter(fileobj, fieldnames=["f1", "f2", "f3"])
             writer.writeheader()
             fileobj.seek(0)
             self.assertEqual(fileobj.readline(), "f1,f2,f3\r\n")
             writer.writerow({"f1": 10, "f3": "abc"})
             fileobj.seek(0)
-            fileobj.readline() # header
+            fileobj.readline()  # header
             self.assertEqual(fileobj.read(), "10,,abc\r\n")
         finally:
             fileobj.close()
@@ -605,7 +627,8 @@ class TestDictFields(unittest.TestCase):
             fileobj.seek(0)
             reader = csv.DictReader(fileobj,
                                     fieldnames=["f1", "f2", "f3"])
-            self.assertEqual(reader.next(), {"f1": '1', "f2": '2', "f3": 'abc'})
+            self.assertEqual(reader.next(),
+                             {"f1": '1', "f2": '2', "f3": 'abc'})
         finally:
             fileobj.close()
             os.unlink(name)
@@ -618,7 +641,8 @@ class TestDictFields(unittest.TestCase):
             fileobj.seek(0)
             reader = csv.DictReader(fileobj)
             self.assertEqual(reader.fieldnames, ["f1", "f2", "f3"])
-            self.assertEqual(reader.next(), {"f1": '1', "f2": '2', "f3": 'abc'})
+            self.assertEqual(reader.next(),
+                             {"f1": '1', "f2": '2', "f3": 'abc'})
         finally:
             fileobj.close()
             os.unlink(name)
@@ -633,7 +657,8 @@ class TestDictFields(unittest.TestCase):
             f.seek(0)
             reader = csv.DictReader(f, fieldnames=csv.reader(f).next())
             self.assertEqual(reader.fieldnames, ["f1", "f2", "f3"])
-            self.assertEqual(reader.next(), {"f1": '1', "f2": '2', "f3": 'abc'})
+            self.assertEqual(reader.next(),
+                             {"f1": '1', "f2": '2', "f3": 'abc'})
         finally:
             f.close()
             os.unlink(name)
@@ -730,7 +755,7 @@ class TestDictFields(unittest.TestCase):
                                          "s2": 'def'})
 
     def test_read_with_blanks(self):
-        reader = csv.DictReader(["1,2,abc,4,5,6\r\n","\r\n",
+        reader = csv.DictReader(["1,2,abc,4,5,6\r\n", "\r\n",
                                  "1,2,abc,4,5,6\r\n"],
                                 fieldnames="1 2 3 4 5 6".split())
         self.assertEqual(reader.next(), {"1": '1', "2": '2', "3": 'abc',
@@ -744,6 +769,7 @@ class TestDictFields(unittest.TestCase):
                                 delimiter=';')
         self.assertEqual(reader.next(), {"1": '1', "2": '2', "3": 'abc',
                                          "4": '4', "5": '5', "6": '6'})
+
 
 class TestArrayWrites(unittest.TestCase):
     def test_int_write(self):
@@ -802,7 +828,8 @@ class TestArrayWrites(unittest.TestCase):
             os.unlink(name)
 
     def test_char_write(self):
-        import array, string
+        import array
+        import string
         a = array.array('c', string.letters)
         fd, name = tempfile.mkstemp()
         fileobj = os.fdopen(fd, "w+b")
@@ -823,7 +850,7 @@ class TestUnicode(unittest.TestCase):
                                  "Marc André Lemburg,"
                                  "Guido van Rossum,"
                                  "François Pinard\r\n"),
-                                 data_encoding='iso-8859-1')
+                        data_encoding='iso-8859-1')
         reader = csv.reader(f)
         self.assertEqual(list(reader), [[u"Martin von Löwis",
                                          u"Marc André Lemburg",
@@ -840,7 +867,8 @@ class TestUnicodeErrors(unittest.TestCase):
 
     def test_encode_error_dictwriter(self):
         fd = StringIO()
-        dw = csv.DictWriter(fd, ['col1'], encoding='cp1252', errors='xmlcharrefreplace')
+        dw = csv.DictWriter(fd, ['col1'], encoding='cp1252',
+                            errors='xmlcharrefreplace')
         dw.writerow({'col1': unichr(2604)})
         self.assertEqual(fd.getvalue(), '&#2604;\r\n')
 


### PR DESCRIPTION
`unicodecsv`'s code does not currently follow the [PEP 8 Style Guide](https://www.python.org/dev/peps/pep-0008/). This pull request does not change any functionality, but instead reformats all Python code in the project to comply with PEP 8.