### PR TITLE
Python 3 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ python:
     - "2.7"
     - "3.3"
     - "3.4"
+    - "3.5"
     - "pypy"
 install: pip install tox-travis
 script: tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: false
 language: python
 python:
     - "2.6"

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,5 +6,6 @@ python:
     - "3.4"
     - "3.5"
     - "pypy"
+    - "pypy3"
 install: pip install tox-travis
 script: tox

--- a/README.rst
+++ b/README.rst
@@ -23,6 +23,3 @@ You can work around it by encoding everything just before calling write (or just
    True
 
 Note that unicodecsv expects a bytestream, not unicode -- so there's no need to use `codecs.open` or similar wrappers.  Plain `open(..., 'rb')` will do.
-
-(Version 0.13.0 is the last version to support python 2.6.  See c0b7655248c4249 for the breaking change.)
-

--- a/README.rst
+++ b/README.rst
@@ -10,18 +10,17 @@ Python 2's csv module doesn't easily deal with unicode strings, leading to the d
 
 You can work around it by encoding everything just before calling write (or just after read), but why not add support to the serializer?
 
-::
+.. code-block:: pycon
 
-   >>> import unicodecsv
-   >>> from cStringIO import StringIO
-   >>> f = StringIO()
-   >>> w = unicodecsv.writer(f, encoding='utf-8')
-   >>> w.writerow((u'é', u'ñ'))
-   >>> f.seek(0)
-   >>> r = unicodecsv.reader(f, encoding='utf-8')
-   >>> row = r.next()
-   >>> print row[0], row[1]
-   é ñ
+   >>> import unicodecsv as csv
+   >>> from io import BytesIO
+   >>> f = BytesIO()
+   >>> w = csv.writer(f, encoding='utf-8')
+   >>> _ = w.writerow((u'é', u'ñ'))
+   >>> _ = f.seek(0)
+   >>> r = csv.reader(f, encoding='utf-8')
+   >>> next(r) == [u'é', u'ñ']
+   True
 
 Note that unicodecsv expects a bytestream, not unicode -- so there's no need to use `codecs.open` or similar wrappers.  Plain `open(..., 'rb')` will do.
 

--- a/runtests.py
+++ b/runtests.py
@@ -11,6 +11,7 @@ def get_suite():
     loader = unittest2.TestLoader()
     suite = loader.discover(start_module)
     suite.addTest(doctest.DocTestSuite(start_module))
+    suite.addTest(doctest.DocFileSuite('README.rst', optionflags=doctest.ELLIPSIS))
 
     return suite
 

--- a/runtests.py
+++ b/runtests.py
@@ -3,13 +3,14 @@ import unittest2
 import doctest
 
 def get_suite():
-    # no tests under python 3 since we simply defer to the vanilla module.
     if sys.version_info >= (3, 0):
-        return unittest2.TestSuite()
+        start_module = 'unicodecsv.py3'
+    else:
+        start_module = 'unicodecsv.py2'
 
     loader = unittest2.TestLoader()
-    suite = loader.discover('unicodecsv.py2')
-    suite.addTest(doctest.DocTestSuite('unicodecsv.py2'))
+    suite = loader.discover(start_module)
+    suite.addTest(doctest.DocTestSuite(start_module))
 
     return suite
 

--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,7 @@ setup(
                 'Programming Language :: Python :: 2.7',
                 'Programming Language :: Python :: 3.3',
                 'Programming Language :: Python :: 3.4',
+                'Programming Language :: Python :: 3.5',
                 'Programming Language :: Python :: Implementation :: CPython',],
 )
 

--- a/setup.py
+++ b/setup.py
@@ -25,6 +25,7 @@ setup(
                 'Programming Language :: Python :: 3.3',
                 'Programming Language :: Python :: 3.4',
                 'Programming Language :: Python :: 3.5',
+                'Programming Language :: Python :: Implementation :: PyPy',
                 'Programming Language :: Python :: Implementation :: CPython',],
 )
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py33, py34, py35, pypy, pypy3
+envlist = py26, py27, py33, py34, py35, pypy, pypy3
 
 [testenv]
 commands = python setup.py test

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py33, py34, py35, pypy
+envlist = py27, py33, py34, py35, pypy, pypy3
 
 [testenv]
 commands = python setup.py test

--- a/unicodecsv/py3.py
+++ b/unicodecsv/py3.py
@@ -1,2 +1,95 @@
 # -*- coding: utf-8 -*-
+import csv
 from csv import *
+
+
+class _UnicodeWriteWrapper(object):
+    """Simple write() wrapper that converts unicode to bytes."""
+
+    def __init__(self, binary, encoding, errors):
+        self.binary = binary
+        self.encoding = encoding
+        self.errors = errors
+
+    def write(self, string):
+        return self.binary.write(string.encode(self.encoding, self.errors))
+
+
+class UnicodeWriter(object):
+    def __init__(self, f, dialect=csv.excel, encoding='utf-8', errors='strict',
+                 *args, **kwds):
+        if f is None:
+            raise TypeError
+
+        f = _UnicodeWriteWrapper(f, encoding=encoding, errors=errors)
+        self.writer = csv.writer(f, dialect, *args, **kwds)
+
+    def writerow(self, row):
+        return self.writer.writerow(row)
+
+    def writerows(self, rows):
+        return self.writer.writerows(rows)
+
+    @property
+    def dialect(self):
+        return self.writer.dialect
+
+
+class UnicodeReader(object):
+    def __init__(self, f, dialect=None, encoding='utf-8', errors='strict',
+                 **kwds):
+
+        format_params = ['delimiter', 'doublequote', 'escapechar',
+                     'lineterminator', 'quotechar', 'quoting',
+                     'skipinitialspace']
+
+        if dialect is None:
+            if not any([kwd_name in format_params
+                        for kwd_name in kwds.keys()]):
+                dialect = csv.excel
+
+        f = (bs.decode(encoding, errors=errors) for bs in f)
+        self.reader = csv.reader(f, dialect, **kwds)
+
+    def __next__(self):
+        return self.reader.__next__()
+
+    def __iter__(self):
+        return self
+
+    @property
+    def dialect(self):
+        return self.reader.dialect
+
+    @property
+    def line_num(self):
+        return self.reader.line_num
+
+
+writer = UnicodeWriter
+reader = UnicodeReader
+
+
+class DictWriter(csv.DictWriter):
+    def __init__(self, csvfile, fieldnames, restval='',
+                 extrasaction='raise', dialect='excel', encoding='utf-8',
+                 errors='strict', *args, **kwds):
+        super().__init__(csvfile, fieldnames, restval,
+                         extrasaction, dialect, *args, **kwds)
+        self.writer = UnicodeWriter(csvfile, dialect, encoding=encoding,
+                                    errors=errors, *args, **kwds)
+        self.encoding_errors = errors
+
+    def writeheader(self):
+        header = dict(zip(self.fieldnames, self.fieldnames))
+        self.writerow(header)
+
+
+class DictReader(csv.DictReader):
+    def __init__(self, csvfile, fieldnames=None, restkey=None, restval=None,
+                 dialect='excel', encoding='utf-8', errors='strict', *args,
+                 **kwds):
+        csv.DictReader.__init__(self, csvfile, fieldnames, restkey, restval,
+                                dialect, *args, **kwds)
+        self.reader = UnicodeReader(csvfile, dialect, encoding=encoding,
+                                    errors=errors, *args, **kwds)

--- a/unicodecsv/test.py
+++ b/unicodecsv/test.py
@@ -147,7 +147,10 @@ class Test_Csv(unittest.TestCase):
             os.unlink(name)
 
     def test_write_arg_valid(self):
-        self.assertRaises(csv.Error, self._write_test, None, '')
+        import sys
+        pypy3 = hasattr(sys, 'pypy_version_info') and sys.version_info.major == 3
+
+        self.assertRaises(TypeError if pypy3 else csv.Error, self._write_test, None, '')
         self._write_test((), b'')
         self._write_test([None], b'""')
         self.assertRaises(csv.Error, self._write_test,

--- a/unicodecsv/test.py
+++ b/unicodecsv/test.py
@@ -336,7 +336,7 @@ class TestDialectRegistry(unittest.TestCase):
         expected_dialects.sort()
         csv.register_dialect(name, myexceltsv)
         try:
-            self.assertTrue(csv.get_dialect(name).delimiter, '\t')
+            self.assertEqual(csv.get_dialect(name).delimiter, '\t')
             got_dialects = csv.list_dialects()
             got_dialects.sort()
             self.assertEqual(expected_dialects, got_dialects)
@@ -347,8 +347,8 @@ class TestDialectRegistry(unittest.TestCase):
         name = 'fedcba'
         csv.register_dialect(name, delimiter=';')
         try:
-            self.assertTrue(csv.get_dialect(name).delimiter, '\t')
-            self.assertTrue(list(csv.reader([b'X;Y;Z'], name)), ['X', 'Y', 'Z'])
+            self.assertNotEqual(csv.get_dialect(name).delimiter, '\t')
+            self.assertEqual(list(csv.reader([b'X;Y;Z'], name)), [[u'X', u'Y', u'Z']])
         finally:
             csv.unregister_dialect(name)
 


### PR DESCRIPTION
Fixes #57

This introduces real Python 3 support. Python 3's csv module is great, but it's not reasonable to attempt to write code that is compatible with Python 2 and 3 with unicodecsv. This fixes that.

Start by running the test suite for Python 3. This involved a _lot_ of test changes to make them Python 3 compatible, as well as writing more code into the `py3` module.

Then make sure that the example in the README works for Python 2 and 3, and also add that to the test runner, so that we're sure we don't screw it up again. I had to use `_` to capture a couple variables, because their output is different on Python 2 than Python 3, because the `csv` module in each deals with and reports write counts in the native `str` type.