### PR TITLE
Add a safe decode function around f

### DIFF
--- a/unicodecsv/py3.py
+++ b/unicodecsv/py3.py
@@ -48,7 +48,13 @@ class UnicodeReader(object):
                         for kwd_name in kwds.keys()]):
                 dialect = csv.excel
 
-        f = (bs.decode(encoding, errors=errors) for bs in f)
+        def _safe_decode(bs):
+            if not isinstance(bs, str):
+                return bs.decode(encoding, errors=errors)
+            else:
+                return bs
+
+        f = (_safe_decode(bs) for bs in f)
         self.reader = csv.reader(f, dialect, **kwds)
 
     def __next__(self):


### PR DESCRIPTION
If f already contains a str object, then the UnicodeReader fails. To get around that, I have added a _safe_decode function that does not decode if f already contains str objects.