### PR TITLE
Add python versions and power support ppc64le

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,22 @@
 sudo: false
 language: python
 python:
-    - "2.6"
     - "2.7"
-    - "3.3"
     - "3.4"
     - "3.5"
+    - "3.6"
+    - "3.7"
+    - "3.8"
     - "pypy"
     - "pypy3"
+arch:
+    - amd64
+    - ppc64le
+jobs:
+  exclude:
+    - arch: ppc64le
+      python: pypy
+    - arch: ppc64le
+      python: pypy3
 install: pip install tox-travis
 script: tox


### PR DESCRIPTION
Added python versions and power support for the travis.yml file with ppc64le. This is part of the Ubuntu distribution for ppc64le. This helps us simplify testing later when distributions are re-building and re-releasing.