### PR TITLE
Remove auto-version since it makes bazel unhappy

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 import os
 from setuptools import setup, find_packages
 
-version = __import__('unicodecsv').__version__
+version = '0.14.2'
 
 setup(
     name='unicodecsv',

--- a/unicodecsv/__init__.py
+++ b/unicodecsv/__init__.py
@@ -7,5 +7,5 @@ if sys.version_info >= (3, 0):
 else:
     from unicodecsv.py2 import *
 
-VERSION = (0, 14, 1)
+VERSION = (0, 14, 2)
 __version__ = ".".join(map(str, VERSION))


### PR DESCRIPTION
Per this now-closed PR:
https://github.com/jdunck/python-unicodecsv/pull/96/files